### PR TITLE
Feature/onedrive token storage

### DIFF
--- a/src/onedrive/auth.ts
+++ b/src/onedrive/auth.ts
@@ -80,13 +80,13 @@ export async function getAccessToken(
             return {
                 homeAccountId: response.account.homeAccountId,
                 accessToken: response.accessToken,
-                expiresOn: response.expiresOn ?? undefined //TODO: null coalescing is used, because response.expiresOn can return null, which it didn't in previous builds
+                expiresOn: response.expiresOn?.getTime() ?? (new Date()).getTime()
             };
         } else {
             return undefined;
         }
     } catch (e) {
-        console.log(JSON.stringify(e));
+        console.warn(JSON.stringify(e));
         return undefined;
     }
 }
@@ -113,13 +113,13 @@ export async function getAccessTokenSilent(
                 return {
                     homeAccountId: homeAccountId,
                     accessToken: response.accessToken,
-                    expiresOn: response.expiresOn ?? undefined //TODO: null coalescing is used, because response.expiresOn can return null, which it didn't in previous builds
+                    expiresOn: response.expiresOn?.getTime() ?? (new Date()).getTime() 
                 };
             }
         }
         return undefined;
     } catch (e) {
-        console.log(JSON.stringify(e));
+        console.warn(JSON.stringify(e));
         return undefined;
     }
 }

--- a/src/onedrive/models/onedriveTokenModel.ts
+++ b/src/onedrive/models/onedriveTokenModel.ts
@@ -1,5 +1,5 @@
 export interface OneDriveTokenModel {
     homeAccountId: string;
-    accessToken?: string;
-    expiresOn?: Date;
+    accessToken: string;
+    expiresOn: number;
 }

--- a/src/routes/onedrive.ts
+++ b/src/routes/onedrive.ts
@@ -50,7 +50,12 @@ onedriveRouter.get('/displayTokens', async (req: any, res: any) => { // Dummy en
  * @returns URL to redirect to
  */
 function generateRedirectUrl(account: OneDriveTokenModel): string {
-    return process.env.ONEDRIVE_FRONTEND_REDIRECT + '?homeAccountId=' + encodeURIComponent(account.homeAccountId) + '&accessToken=' + 
+    let redirectUri = process.env.ONEDRIVE_FRONTEND_REDIRECT;
+    if (!redirectUri) {
+        redirectUri = '/onedrive/displayTokens'; // Set a default uri if none is specified in env
+    } 
+
+    return redirectUri + '?homeAccountId=' + encodeURIComponent(account.homeAccountId) + '&accessToken=' + 
         encodeURIComponent(account.accessToken) + '&expiresOn=' + account.expiresOn.toString();
 }
 

--- a/src/routes/onedrive.ts
+++ b/src/routes/onedrive.ts
@@ -1,4 +1,5 @@
 import { getAccessToken, getAccessTokenSilent, getAuthorizationUrl } from '../onedrive/auth';
+import { OneDriveTokenModel } from '../onedrive/models/onedriveTokenModel';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const onedriveRouter = require('express').Router();
@@ -8,7 +9,7 @@ onedriveRouter.get('/login', async (req: any, res: any) => {
     if (req.query.homeAccountId) {
         const account = await getAccessTokenSilent(req.query.homeAccountId);
         if (account) {
-            return res.status(200).json(account);
+            return res.redirect(generateRedirectUrl(account));
         }
     }
 
@@ -25,7 +26,7 @@ onedriveRouter.get('/redirect', async (req: any, res: any) => {
     if (req.query.code) {
         const account = await getAccessToken(req.query.code);
         if (account) {
-            return res.status(200).json(account);
+            return res.redirect(generateRedirectUrl(account));
         } else {
             return res.status(403).send();
         }
@@ -33,5 +34,24 @@ onedriveRouter.get('/redirect', async (req: any, res: any) => {
         return res.status(400).send();
     }
 });
+
+onedriveRouter.get('/displayTokens', async (req: any, res: any) => { // Dummy endpoint for testing purposes
+    if (req.query.homeAccountId && req.query.accessToken && req.query.expiresOn ) {
+        const account: OneDriveTokenModel = req.query as OneDriveTokenModel;
+        return res.status(200).json(account);
+    } else {
+        return res.status(400).send();
+    }
+});
+
+/**
+ * Generates a redirect URL where account details are passed as query parameters.
+ * @param account Account details to generate URL for
+ * @returns URL to redirect to
+ */
+function generateRedirectUrl(account: OneDriveTokenModel): string {
+    return process.env.ONEDRIVE_FRONTEND_REDIRECT + '?homeAccountId=' + encodeURIComponent(account.homeAccountId) + '&accessToken=' + 
+        encodeURIComponent(account.accessToken) + '&expiresOn=' + account.expiresOn.toString();
+}
 
 module.exports = onedriveRouter;


### PR DESCRIPTION
Tokens are intended to be stored locally. A redirect is made to a given url in .env or default to /onedrive/displayTokens. In this way, frontend can receive tokens and store them in local storage.